### PR TITLE
use global hugo function, url deprecated, rsslink deprecated

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,14 +2,14 @@
 <div class="site-footer">
   <div class="copyright">{{ .Site.Copyright | safeHTML }}</div>
   <ul class="site-footer-items">
-    {{- if .RelPermalink }}
+    {{- with .OutputFormats.Get "RSS" }}
     <li class="site-footer-item-rsslink">
-      <a href="{{ .RelPermalink | relURL }}" type="application/rss+xml" target="_blank" title="RSS">
+      <a href="{{ .Permalink }}" type="application/rss+xml" target="_blank" title="RSS">
         <i class="fas fa-rss"></i>
       </a>
     </li>
     {{- end }}
-    {{- range .Site.Menus.footer }}
+        {{- range .Site.Menus.footer }}
     <li class="site-footer-item-{{ .Identifier }}"><a href="{{ .URL | safeURL }}" title="{{ .Name }}">{{ .Name }}</a></li>
     {{- end }}
   </ul>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,9 +2,9 @@
 <div class="site-footer">
   <div class="copyright">{{ .Site.Copyright | safeHTML }}</div>
   <ul class="site-footer-items">
-    {{- if .RSSLink }}
+    {{- if .RelPermalink }}
     <li class="site-footer-item-rsslink">
-      <a href="{{ .RSSLink | relURL }}" type="application/rss+xml" target="_blank" title="RSS">
+      <a href="{{ .RelPermalink | relURL }}" type="application/rss+xml" target="_blank" title="RSS">
         <i class="fas fa-rss"></i>
       </a>
     </li>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -37,9 +37,9 @@
   {{- end }}
   {{ hugo.Generator }}
 
-  {{- if .RelPermalink }}
-  <link href="{{ .Permalink | relURL }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-  <link href="{{ .Permalink | relURL }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+  {{- with .OutputFormats.Get "RSS" }}
+  <link href="{{ .Permalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
+  <link href="{{ .Permalink }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" />
   {{- end }}
 
   {{- partial "head_custom.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -20,7 +20,7 @@
   <link rel='icon' type='image/x-icon' href="{{ . | absURL }}" />
   {{- end }}
   <meta property="og:site_name" content="{{ .Site.Title }}" />
-  <meta property="og:url" content="{{ .URL | absURL }}" />
+  <meta property="og:url" content="{{ .Permalink | absURL }}" />
   {{- if .IsPage }}
   <meta property="og:type" content="article" />
   {{- else }}
@@ -35,10 +35,11 @@
   <meta name="twitter:site" content="@{{ . }}" />
   <meta name="twitter:creator" content="@{{ . }}" />
   {{- end }}
-  {{ .Hugo.Generator }}
-  {{- if .RSSLink }}
-  <link href="{{ .RSSLink | relURL }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-  <link href="{{ .RSSLink | relURL }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+  {{ hugo.Generator }}
+
+  {{- if .RelPermalink }}
+  <link href="{{ .Permalink | relURL }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+  <link href="{{ .Permalink | relURL }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
   {{- end }}
 
   {{- partial "head_custom.html" . }}


### PR DESCRIPTION
The hugo dev team modified quite a few things with version 0.55

`Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.`

` Page's .URL is deprecated and will be removed in a future release. Use .Permalink or .RelPermalink. If what you want is the front matter URL value, use .Params.url.`

and 

` Page's .RSSLink is deprecated and will be removed in a future release. Use the Output Format's link, e.g. something like: 
    {{ with .OutputFormats.Get "RSS" }}{{ . RelPermalink }}{{ end }}.`

the last one is tricky, but don't despair, this pull request fixes it all of them for you. :)

one important thing to remember, v 0.55 parted considerably from v 0.54