### PR TITLE
Fix: Update deprecated `DisqusShortname` usage in Whiteplain Hugo theme

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -55,7 +55,7 @@
 
     {{ partial "share.html" . }}
 
-    {{- if and .Site.DisqusShortname (or (not (isset .Params "comments")) (eq .Params.comments nil) .Params.comments) }}
+    {{- if and .Site.Config.Services.Disqus.Shortname (or (not (isset .Params "comments")) (eq .Params.comments nil) .Params.comments) }}
     <div class="disqus-comments">
       {{ template "_internal/disqus.html" . }}
     </div>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3,7 +3,7 @@ html {
 }
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Segoe UI", "Noto Sans Japanese", "ヒラギノ角ゴ ProN W3", Meiryo, sans-serif;
-  color: #444444;
+  color: #000000;
   overflow-y: scroll;
   line-height: 1.2;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3,7 +3,7 @@ html {
 }
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Segoe UI", "Noto Sans Japanese", "ヒラギノ角ゴ ProN W3", Meiryo, sans-serif;
-  color: #000000;
+  color: #444444;
   overflow-y: scroll;
   line-height: 1.2;
 }


### PR DESCRIPTION
## Description

I have been using your theme to create a site with the Hugo site generator and noticed a small bug that needs attention. I have opened this PR to resolve this issue.

## Steps to Reproduce

1. Run the following command:

    ```bash
    hugo server --buildDraft
    ```

## Error Message

    ```
    ERROR deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.134.0. Use .Site.Config.Services.Disqus.Shortname instead.
    Built in 12 ms
    Error: error building site: logged 1 error(s)
    ```

### Software Version

- Hugo v0.134.0

## Proposed Solution

This PR updates the theme by replacing `.Site.DisqusShortname` with `.Site.Config.Services.Disqus.Shortname` in the `layouts/_default/single.html` file.
